### PR TITLE
Add s3-no-concurrent-write in some necessary places

### DIFF
--- a/crates/deltalake-core/src/lib.rs
+++ b/crates/deltalake-core/src/lib.rs
@@ -77,7 +77,11 @@ compile_error!(
     "Features parquet and parquet2 are mutually exclusive and cannot be enabled together"
 );
 
-#[cfg(all(feature = "s3", feature = "s3-native-tls"))]
+#[cfg(all(
+    feature = "s3",
+    feature = "s3-native-tls",
+    feature = "s3-no-concurrent-write"
+))]
 compile_error!(
     "Features s3 and s3-native-tls are mutually exclusive and cannot be enabled together"
 );

--- a/crates/deltalake-core/src/lib.rs
+++ b/crates/deltalake-core/src/lib.rs
@@ -77,10 +77,10 @@ compile_error!(
     "Features parquet and parquet2 are mutually exclusive and cannot be enabled together"
 );
 
-#[cfg(all(
-    feature = "s3",
-    feature = "s3-native-tls",
-    feature = "s3-no-concurrent-write"
+#[cfg(any(
+    all(feature = "s3", feature = "s3-native-tls"),
+    all(feature = "s3-no-concurrent-write", feature = "s3"),
+    all(feature = "s3-no-concurrent-write", feature = "s3-native-tls")
 ))]
 compile_error!(
     "Features s3 and s3-native-tls are mutually exclusive and cannot be enabled together"

--- a/crates/deltalake-core/src/storage/config.rs
+++ b/crates/deltalake-core/src/storage/config.rs
@@ -15,11 +15,19 @@ use crate::errors::{DeltaResult, DeltaTableError};
 use crate::logstore::default_logstore::DefaultLogStore;
 use crate::logstore::LogStoreRef;
 
-#[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
+#[cfg(any(
+    feature = "s3",
+    feature = "s3-native-tls",
+    feature = "s3-no-concurrent-write"
+))]
 use super::s3::{S3StorageBackend, S3StorageOptions};
 #[cfg(feature = "hdfs")]
 use datafusion_objectstore_hdfs::object_store::hdfs::HadoopFileSystem;
-#[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
+#[cfg(any(
+    feature = "s3",
+    feature = "s3-native-tls",
+    feature = "s3-no-concurrent-write"
+))]
 use object_store::aws::AmazonS3ConfigKey;
 #[cfg(feature = "azure")]
 use object_store::azure::AzureConfigKey;
@@ -29,7 +37,8 @@ use object_store::gcp::GoogleConfigKey;
     feature = "s3",
     feature = "s3-native-tls",
     feature = "gcs",
-    feature = "azure"
+    feature = "azure",
+    feature = "s3-no-concurrent-write"
 ))]
 use std::str::FromStr;
 
@@ -163,7 +172,11 @@ impl StorageOptions {
     }
 
     /// Add values from the environment to storage options
-    #[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
+    #[cfg(any(
+        feature = "s3",
+        feature = "s3-native-tls",
+        feature = "s3-no-concurrent-write"
+    ))]
     pub fn with_env_s3(&mut self) {
         for (os_key, os_value) in std::env::vars_os() {
             if let (Some(key), Some(value)) = (os_key.to_str(), os_value.to_str()) {
@@ -197,7 +210,11 @@ impl StorageOptions {
     }
 
     /// Subset of options relevant for s3 storage
-    #[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
+    #[cfg(any(
+        feature = "s3",
+        feature = "s3-native-tls",
+        feature = "s3-no-concurrent-write"
+    ))]
     pub fn as_s3_options(&self) -> HashMap<AmazonS3ConfigKey, String> {
         self.0
             .iter()
@@ -251,7 +268,11 @@ pub fn configure_store(
             Ok(Arc::new(FileStorageBackend::try_new(path)?))
         }
         ObjectStoreScheme::Memory => url_prefix_handler(InMemory::new(), Path::parse(url.path())?),
-        #[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
+        #[cfg(any(
+            feature = "s3",
+            feature = "s3-native-tls",
+            feature = "s3-no-concurrent-write"
+        ))]
         ObjectStoreScheme::AmazonS3 => {
             options.with_env_s3();
             let (store, prefix) = parse_url_opts(url, options.as_s3_options())?;

--- a/crates/deltalake-core/src/storage/config.rs
+++ b/crates/deltalake-core/src/storage/config.rs
@@ -163,7 +163,7 @@ impl StorageOptions {
     }
 
     /// Add values from the environment to storage options
-    #[cfg(any(feature = "s3", feature = "s3-native-tls"))]
+    #[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
     pub fn with_env_s3(&mut self) {
         for (os_key, os_value) in std::env::vars_os() {
             if let (Some(key), Some(value)) = (os_key.to_str(), os_value.to_str()) {
@@ -197,7 +197,7 @@ impl StorageOptions {
     }
 
     /// Subset of options relevant for s3 storage
-    #[cfg(any(feature = "s3", feature = "s3-native-tls"))]
+    #[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
     pub fn as_s3_options(&self) -> HashMap<AmazonS3ConfigKey, String> {
         self.0
             .iter()

--- a/crates/deltalake-core/src/storage/config.rs
+++ b/crates/deltalake-core/src/storage/config.rs
@@ -251,7 +251,7 @@ pub fn configure_store(
             Ok(Arc::new(FileStorageBackend::try_new(path)?))
         }
         ObjectStoreScheme::Memory => url_prefix_handler(InMemory::new(), Path::parse(url.path())?),
-        #[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-concurrent-write"))]
+        #[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
         ObjectStoreScheme::AmazonS3 => {
             options.with_env_s3();
             let (store, prefix) = parse_url_opts(url, options.as_s3_options())?;

--- a/crates/deltalake-core/src/storage/config.rs
+++ b/crates/deltalake-core/src/storage/config.rs
@@ -15,11 +15,11 @@ use crate::errors::{DeltaResult, DeltaTableError};
 use crate::logstore::default_logstore::DefaultLogStore;
 use crate::logstore::LogStoreRef;
 
-#[cfg(any(feature = "s3", feature = "s3-native-tls"))]
+#[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
 use super::s3::{S3StorageBackend, S3StorageOptions};
 #[cfg(feature = "hdfs")]
 use datafusion_objectstore_hdfs::object_store::hdfs::HadoopFileSystem;
-#[cfg(any(feature = "s3", feature = "s3-native-tls"))]
+#[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
 use object_store::aws::AmazonS3ConfigKey;
 #[cfg(feature = "azure")]
 use object_store::azure::AzureConfigKey;

--- a/crates/deltalake-core/src/storage/config.rs
+++ b/crates/deltalake-core/src/storage/config.rs
@@ -251,7 +251,7 @@ pub fn configure_store(
             Ok(Arc::new(FileStorageBackend::try_new(path)?))
         }
         ObjectStoreScheme::Memory => url_prefix_handler(InMemory::new(), Path::parse(url.path())?),
-        #[cfg(any(feature = "s3", feature = "s3-native-tls"))]
+        #[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-concurrent-write"))]
         ObjectStoreScheme::AmazonS3 => {
             options.with_env_s3();
             let (store, prefix) = parse_url_opts(url, options.as_s3_options())?;

--- a/crates/deltalake-core/src/storage/mod.rs
+++ b/crates/deltalake-core/src/storage/mod.rs
@@ -8,7 +8,7 @@ pub mod config;
 pub mod file;
 pub mod utils;
 
-#[cfg(any(feature = "s3", feature = "s3-native-tls"))]
+#[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write" ))]
 pub mod s3;
 
 pub use object_store::path::{Path, DELIMITER};

--- a/crates/deltalake-core/src/storage/mod.rs
+++ b/crates/deltalake-core/src/storage/mod.rs
@@ -8,7 +8,11 @@ pub mod config;
 pub mod file;
 pub mod utils;
 
-#[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write" ))]
+#[cfg(any(
+    feature = "s3",
+    feature = "s3-native-tls",
+    feature = "s3-no-concurrent-write"
+))]
 pub mod s3;
 
 pub use object_store::path::{Path, DELIMITER};

--- a/crates/deltalake-core/src/storage/s3.rs
+++ b/crates/deltalake-core/src/storage/s3.rs
@@ -17,7 +17,9 @@ use rusoto_core::{HttpClient, Region};
 use rusoto_credential::AutoRefreshingProvider;
 #[cfg(feature = "s3-concurrent-write")]
 use rusoto_sts::WebIdentityProvider;
+#[cfg(feature = "s3-concurrent-write")]
 use serde::Deserialize;
+#[cfg(feature = "s3-concurrent-write")]
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -26,6 +28,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::AsyncWrite;
 
+#[cfg(feature = "s3-concurrent-write")]
 const STORE_NAME: &str = "DeltaS3ObjectStore";
 #[cfg(feature = "s3-concurrent-write")]
 const DEFAULT_MAX_RETRY_ACQUIRE_LOCK_ATTEMPTS: u32 = 1_000;
@@ -519,7 +522,7 @@ impl ObjectStore for S3StorageBackend {
         if let Some(lock_client) = &self.s3_lock_client {
             lock_client.rename_with_lock(self, from, to).await?;
             return Ok(());
-        } 
+        }
         if self.allow_unsafe_rename {
             self.inner.rename(from, to).await?;
         } else {

--- a/crates/deltalake-core/tests/common/mod.rs
+++ b/crates/deltalake-core/tests/common/mod.rs
@@ -21,7 +21,7 @@ pub mod clock;
 pub mod datafusion;
 #[cfg(feature = "hdfs")]
 pub mod hdfs;
-#[cfg(any(feature = "s3", feature = "s3-native-tls"))]
+#[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
 pub mod s3;
 
 #[derive(Default)]
@@ -47,7 +47,7 @@ impl TestContext {
             Ok("LOCALFS") | Err(std::env::VarError::NotPresent) => setup_local_context().await,
             #[cfg(feature = "azure")]
             Ok("AZURE_GEN2") => adls::setup_azure_gen2_context().await,
-            #[cfg(any(feature = "s3", feature = "s3-native-tls"))]
+            #[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
             Ok("S3_LOCAL_STACK") => s3::setup_s3_context().await,
             #[cfg(feature = "hdfs")]
             Ok("HDFS") => hdfs::setup_hdfs_context(),

--- a/crates/deltalake-core/tests/common/mod.rs
+++ b/crates/deltalake-core/tests/common/mod.rs
@@ -21,7 +21,11 @@ pub mod clock;
 pub mod datafusion;
 #[cfg(feature = "hdfs")]
 pub mod hdfs;
-#[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
+#[cfg(any(
+    feature = "s3",
+    feature = "s3-native-tls",
+    feature = "s3-no-concurrent-write"
+))]
 pub mod s3;
 
 #[derive(Default)]
@@ -47,7 +51,11 @@ impl TestContext {
             Ok("LOCALFS") | Err(std::env::VarError::NotPresent) => setup_local_context().await,
             #[cfg(feature = "azure")]
             Ok("AZURE_GEN2") => adls::setup_azure_gen2_context().await,
-            #[cfg(any(feature = "s3", feature = "s3-native-tls", feature = "s3-no-concurrent-write"))]
+            #[cfg(any(
+                feature = "s3",
+                feature = "s3-native-tls",
+                feature = "s3-no-concurrent-write"
+            ))]
             Ok("S3_LOCAL_STACK") => s3::setup_s3_context().await,
             #[cfg(feature = "hdfs")]
             Ok("HDFS") => hdfs::setup_hdfs_context(),

--- a/crates/deltalake-core/tests/integration_read.rs
+++ b/crates/deltalake-core/tests/integration_read.rs
@@ -192,7 +192,11 @@ async fn read_simple_table(integration: &IntegrationContext) -> TestResult {
     let table = DeltaTableBuilder::from_uri(table_uri).with_allow_http(true).with_storage_options(hashmap! {
         dynamo_lock_options::DYNAMO_LOCK_OWNER_NAME.to_string() => "s3::deltars/simple".to_string(),
     }).load().await?;
-    #[cfg(not(any(feature = "s3", feature = "s3-native-tls")))]
+    #[cfg(not(any(
+        feature = "s3",
+        feature = "s3-native-tls",
+        feature = "s3-no-concurrent-write"
+    )))]
     let table = DeltaTableBuilder::from_uri(table_uri)
         .with_allow_http(true)
         .load()


### PR DESCRIPTION
# Description
our s3-no-concurrent-write feature simply omits the dynamic database lock. Hence, theoretically, it needs to be compiled in all places where S3 is being built.
# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
